### PR TITLE
Print-out editor specific inline CSS styles

### DIFF
--- a/src/components.js
+++ b/src/components.js
@@ -1,13 +1,20 @@
 /**
+ * External dependencies
+ */
+import { compact, forEach, map } from 'lodash-es';
+
+/**
  * WordPress dependencies
  */
 const { __ } = wp.i18n;
 const { Spinner } = wp.components;
+const { useEffect } = wp.element;
+const { transformStyles } = wp.blockEditor;
 
 /**
  * A simple component to notify users that their action is being processed.
  *
- * @param {string} label Label shown above spinner.
+ * @param {string} label 	    Label shown above spinner.
  */
 const LoadingSpinner = ( { label } ) => (
 	<>
@@ -18,4 +25,28 @@ const LoadingSpinner = ( { label } ) => (
 	</>
 );
 
-export { LoadingSpinner };
+/**
+ * Applies a series of CSS rule transforms to wrap selectors inside a given class.
+ *
+ * @param  {Object} props 	            Block name/slug/id.
+ * @param  {Array}  props.styles 	    CSS rules.
+ */
+export default function EditorStyles( { styles } ) {
+	useEffect( () => {
+		const updatedStyles = transformStyles( styles, '.editor-styles-wrapper' );
+
+		const nodes = map( compact( updatedStyles ), ( updatedCSS ) => {
+			const node = document.createElement( 'style' );
+			node.innerHTML = updatedCSS;
+			document.body.appendChild( node );
+
+			return node;
+		} );
+
+		return () => forEach( nodes, ( node ) => document.body.removeChild( node ) );
+	}, [ styles ] );
+
+	return null;
+}
+
+export { LoadingSpinner, EditorStyles };

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 export { spacingAttrs } from './attributes';
 export { blockName, blockClassName } from './block-meta';
-export { LoadingSpinner } from './components';
+export { LoadingSpinner, EditorStyles } from './components';
 export { AUTHOR, PREFIX, IMAGE_TYPE, VIDEO_TYPE, POSITION_CLASSNAMES } from './constants';
 export { default as icons } from './icons';
 export {


### PR DESCRIPTION
This PR adds a helper component to print-out block-specific inline CSS styles within the editor context.