### PR TITLE
Add new multiSelectItems utility

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ export { default as isNonEmptyArray } from './is-non-empty-array';
 export { default as insertAtIndex } from './insert-at-index';
 export { default as isPositionCenter } from './is-position-center';
 export { default as jsonify } from './jsonify';
+export { default as multiSelectItems } from './multi-select-items';
 export { default as positionToClassName } from './position-to-class-name';
 export { default as removeAtIndex } from './remove-at-index';
 export { default as selectOptions } from './select-options';

--- a/src/multi-select-items/index.js
+++ b/src/multi-select-items/index.js
@@ -1,0 +1,25 @@
+/**
+ * Utility for libraries from the `Lodash`.
+ *
+ * @ignore
+ */
+import { filter, includes, get } from 'lodash';
+
+/**
+ * Generates an array of objects to be passed to the react `MultiSelect` component.
+ * MultiSelect is a multiple selection dropdown component with `checkboxes`, `search` and `select-all`.
+ *
+ * @function
+ * @since     1.0.0
+ * @param     {Array} posts            The response on the API call of array of post objects.
+ * @param     {Array} selected         The selected posts.
+ * @return    {Array}                  An array of objects containing the label to be shown to the user, and value used to choose the selected value.
+ * @example
+ *
+ * multiSelectItems( [ { "value": 1, "label": "sunt aut facere" }, { "value": 2, "label": "qui est esse" } ], [ 1, 2 ] );
+ *
+ * // => Array [ { "value": 1, "label": "sunt aut facere" }, { "value": 2, "label": "qui est esse" } ]
+ */
+const multiSelectItems = ( posts, selected ) => filter( posts, ( post ) => includes( selected, get( post, 'value' ) ) );
+
+export default multiSelectItems;


### PR DESCRIPTION
In this PR I have added a new `multiSelectItems` utility that simply generates an array of objects based on the selected posts from a list of posts, to be passed to the react `MultiSelect` component.

Please let me know your thoughts on the proposal and if you would like to see any changes or adjustments to the implementation.