### PR TITLE
Add get mailto unit test and custom jest config

### DIFF
--- a/src/get-mailto/test/index.js
+++ b/src/get-mailto/test/index.js
@@ -5,7 +5,7 @@
  */
 import getMailTo from '../';
 
-describe( 'Should return an array with single email address for valid mailto string', () => {
+describe( 'Should return an array with a single email when given a valid `mailto` attribute (string) value', () => {
 	it.each( [
 		[ 'mailto:info@example.com', [ 'info@example.com' ] ],
 		[ 'mailto:info@example.com,', [ 'info@example.com' ] ], // Dangling comma
@@ -19,7 +19,7 @@ describe( 'Should return an array with single email address for valid mailto str
 	} );
 } );
 
-describe( 'Should return an array with all email addresses for valid mailto string with separated email addresses', () => {
+describe( 'Should return an array of valid emails being extracted from the `mailto` attribute (string) value', () => {
 	it.each( [
 		[ 'mailto:info@example.com,another@example.com', [ 'info@example.com', 'another@example.com' ] ],
 		[ 'mailto:info@example.com, another@example.com', [ 'info@example.com', 'another@example.com' ] ],
@@ -28,7 +28,7 @@ describe( 'Should return an array with all email addresses for valid mailto stri
 	} );
 } );
 
-describe( 'Should return "null" for invalid mailto string where no substring matches an email pattern', () => {
+describe( 'Should return `null` when given an invalid `mailto` attribute value where no substring matches a valid email pattern', () => {
 	it.each( [
 		[ 'mailto', null ],
 		[ 'mailto:info@example', null ],
@@ -40,7 +40,7 @@ describe( 'Should return "null" for invalid mailto string where no substring mat
 	} );
 } );
 
-describe( 'Should return "null" for falseful and empty values', () => {
+describe( 'Should return `null` when given falsely argument including but not limited to an array, object, or an empty array', () => {
 	it.each( [
 		[ [ '' ], null ],
 		[ [], null ],


### PR DESCRIPTION
I have re-opened this PR following the necessary refactoring of the test structure for the `get-mailto` utility.

I have tried to follow the guidelines [suggested here](https://developer.wordpress.org/block-editor/contributors/code/testing-overview/#describing-tests) although the example provided is rather simplistic and didn't fully clarify some of the questions.

My main concern and question would be if we should or should not break down the test below into further cases, although I am unsure how (perhaps truncated and intact?):

``` javascript
describe( 'Matching RegEx pattern against multiple valid and invalid addresses should return a single or multiple item array', () => {
	test.each( [
		[ 'mailto:info@example.cominfo@test.com', [ 'info@example.cominfo' ] ], // Missing comma separator
		[ 'mailto:infoexample.com,test@example.com', [ 'test@example.com' ] ], // Missing separator
		[ 'info@example.com,info@test.com', [ 'info@example.com', 'info@test.com' ] ], // Missing mailto
		[ 'mailto:info@@example.com,info@info.com', [ 'info@info.com' ] ], // Multiple '@' signs
		[ 'mailto:ex\\ample@example.com,test\\@info.com', [ 'ample@example.com' ] ], // Double backslash character before separator
		[ 'mailto:exam/ple@example.com,test/@example.com', [ 'ple@example.com' ] ], // Forward slash before separator
		[ 'mailto:in fo@example.com,te st@example.com', [ 'fo@example.com', 'st@example.com' ] ], // Space separated
		[ 'mailto:info@example.com,info@test.com,', [ 'info@example.com', 'info@test.com' ] ], // Dangling comma
		[ 'mailto:info@example.com?test@info.com', [ 'info@example.com', 'test@info.com' ] ], // Special characters instead of comma separator
	] )( 'when given %p it returns %p', ( input, expected ) => {
		expect( getMailTo( input ) ).toStrictEqual( expected );
	} );
} );
```
Please let me know if this general approach is suitable and if the change mentioned above would be necessary.