### PR TITLE
Add block class name unit test

### DIFF
--- a/src/block-class-name/test/index.js
+++ b/src/block-class-name/test/index.js
@@ -5,7 +5,7 @@
  */
 import blockClassName from '../';
 
-describe( 'Should return the block-specific generated CSS class name when given an argument of the class name(s) in string', () => {
+describe( 'Should return the block-specific generated CSS class name when given a string argument containing the class name(s)', () => {
 	it.each( [
 		[ 'wp-block-sixa-spacer', 'wp-block-sixa-spacer' ],
 		[ 'wp-block-sixa-spacer123', 'wp-block-sixa-spacer123' ],
@@ -17,13 +17,13 @@ describe( 'Should return the block-specific generated CSS class name when given 
 	} );
 } );
 
-describe( 'Should return the first element predicate returns truthy for block-specific generated CSS class name when given an argument of the class name(s) in string', () => {
+describe( 'Should return the first block-specific generated CSS class name when given a string argument containing multiple candidates', () => {
 	it.each( [ [ 'wp-block-sixa-spacer wp-block-sixa-container', 'wp-block-sixa-spacer' ] ] )( 'when given %s it returns %s', ( input, expected ) => {
 		expect( blockClassName( input ) ).toBe( expected );
 	} );
 } );
 
-describe( 'Should return `undefined` when a given argument doesn’t contain a valid string of CSS class name(s)', () => {
+describe( 'Should return `undefined` when the given argument doesn’t contain a valid string of CSS class name(s)', () => {
 	it.each( [
 		[ 'wp--block-sixa-spacer', undefined ],
 		[ [ '' ], undefined ],


### PR DESCRIPTION
This PR introduces a unit test setup for the `blockClassName` utility. Please let me know if I should change or adjust the implementation.