### PR TITLE
Add block style slug unit test

### DIFF
--- a/src/block-style-slug/test/index.js
+++ b/src/block-style-slug/test/index.js
@@ -16,7 +16,7 @@ describe( 'Should extract a valid block style name from a given string of CSS cl
 	} );
 } );
 
-describe( 'Should return an empty string when none of the given string argument of CSS class name(s) includes block style class name', () => {
+describe( 'Should return an empty string if the given string argument does not include a block style class name', () => {
 	it.each( [
 		[ 'IS-style-fancy', '' ],
 		[ 'test-class-name', '' ],


### PR DESCRIPTION
This PR introduces a unit test setup for the `blockStyleSlug` utility. Please let me know if I should change or adjust the implementation.