### PR TITLE
Add is-position-center unit test

### DIFF
--- a/src/is-position-center/test/index.js
+++ b/src/is-position-center/test/index.js
@@ -5,8 +5,8 @@
  */
 import isPositionCenter from '../';
 
-describe( "Returns boolean primitive 'true' for string 'center' or 'center center'", () => {
-	test.each( [
+describe( 'Returns boolean primitive "true" for string "center" or "center center"', () => {
+	it.each( [
 		[ 'center', true ],
 		[ 'center center', true ],
 	] )( 'when given %p it returns %p', ( input, expected ) => {
@@ -14,20 +14,23 @@ describe( "Returns boolean primitive 'true' for string 'center' or 'center cente
 	} );
 } );
 
-describe( "Returns boolean primitive 'true' for falseful value", () => {
-	test.each( [
+describe( 'Should return boolean primitive "true" for falseful value', () => {
+	it.each( [
 		[ '', true ],
 		[ null, true ],
 		[ false, true ],
 		[ undefined, true ],
 		[ 0, true ],
+		[ -0, true ],
+		[ 0n, true ],
+		[ NaN, true ],
 	] )( 'when given %p it returns %p', ( input, expected ) => {
 		expect( isPositionCenter( input ) ).toBe( expected );
 	} );
 } );
 
-describe( "Returns boolean primitive 'false' for invalid string", () => {
-	test.each( [
+describe( 'Should return boolean primitive "false" for invalid string', () => {
+	it.each( [
 		[ 'Center', false ],
 		[ 'center  center', false ],
 		[ 'center center center', false ],
@@ -36,14 +39,14 @@ describe( "Returns boolean primitive 'false' for invalid string", () => {
 	} );
 } );
 
-describe( "Returns boolean primitive 'false' for value 'true'", () => {
-	test.each( [ [ true, false ] ] )( 'when given %p it returns %p', ( input, expected ) => {
+describe( 'Should return boolean primitive "false" for value "true"', () => {
+	it.each( [ [ true, false ] ] )( 'when given %p it returns %p', ( input, expected ) => {
 		expect( isPositionCenter( input ) ).toBe( expected );
 	} );
 } );
 
-describe( "Returns boolean primitive 'false' for empty value", () => {
-	test.each( [
+describe( 'Should return boolean primitive "false" for empty value', () => {
+	it.each( [
 		[ [], false ],
 		[ {}, false ],
 	] )( 'when given %p it returns %p', ( input, expected ) => {


### PR DESCRIPTION
This PR introduces a unit test setup for the `isPositionCenter` utility. Please let me know if I should change or adjust the implementation.