### PR TITLE
Add select-options unit test and add @wordpress/i18n to devDep

### DIFF
--- a/src/select-options/test/index.js
+++ b/src/select-options/test/index.js
@@ -98,29 +98,29 @@ describe( 'selectOptions', () => {
 
 	describe( 'Should accept falsey arguments for post objects array', () => {
 		const cases = map( falsey, ( value ) => [ value, testPropertyPath ] );
-		it.each( cases )( 'when given %p with path %o', ( input, value ) => {
-			expect.anything( selectOptions( input, value ) );
+		it.each( cases )( 'when given %p with path %o', ( post, path ) => {
+			expect.anything( selectOptions( post, path ) );
 		} );
 	} );
 
 	describe( 'Should accept empty arguments for post objects array', () => {
 		const cases = map( empties, ( value ) => [ value, testPropertyPath ] );
-		it.each( cases )( 'when given %p with path %o', ( input, value ) => {
-			expect.anything( selectOptions( input, value ) );
+		it.each( cases )( 'when given %p with path %o', ( post, path ) => {
+			expect.anything( selectOptions( post, path ) );
 		} );
 	} );
 
 	describe( 'Should accept falsey arguments for value path', () => {
 		const cases = map( falsey, ( value ) => [ testPostObject, value ] );
-		it.each( cases )( 'when given %p with path %o', ( input, value ) => {
-			expect.anything( selectOptions( input, value ) );
+		it.each( cases )( 'when given %p with path %o', ( post, path ) => {
+			expect.anything( selectOptions( post, path ) );
 		} );
 	} );
 
 	describe( 'Should accept empty arguments for value path', () => {
 		const cases = map( empties, ( value ) => [ testPostObject, value ] );
-		it.each( cases )( 'when given %p with path %o', ( input, value ) => {
-			expect.anything( selectOptions( input, value ) );
+		it.each( cases )( 'when given %p with path %o', ( post, path ) => {
+			expect.anything( selectOptions( post, path ) );
 		} );
 	} );
 


### PR DESCRIPTION
This PR introduces a unit test setup for the `selectOptions` utility. Please let me know if I should change or adjust the implementation.

For this test setup, one aspect differs:

1. The `@wordpress/i18n` dependency from the `option-none.js` file (which is used in the current `selectOptions`) had to be copied over as a `devDependencies` as well in order for the test to run properly.