### PR TITLE
Validate background-image URL argument

### DIFF
--- a/src/background-image-style/index.js
+++ b/src/background-image-style/index.js
@@ -1,4 +1,11 @@
 /**
+ * Utility for libraries from the `Lodash`.
+ *
+ * @ignore
+ */
+import { isString } from 'lodash';
+
+/**
  * Generate inline background-image CSS style based on provided URL.
  *
  * @function
@@ -11,6 +18,7 @@
  *
  * // => Object { backgroundImage: 'url(https://interactive-examples.mdn.mozilla.net/media/examples/lizard.png)' }
  */
-const backgroundImageStyle = ( url ) => ( url && url.match( /\w+\.(jpg|jpeg|gif|png|tiff|bmp)(\?(.*))?$/gim ) ? { backgroundImage: `url(${ url })` } : {} );
+const backgroundImageStyle = ( url ) =>
+	isString( url ) && url.match( /\w+\.(jpg|jpeg|gif|png|tiff|bmp)(\?(.*))?$/gim ) ? { backgroundImage: `url(${ url })` } : {};
 
 export default backgroundImageStyle;


### PR DESCRIPTION
Checks whether the image URL provided as an argument for the `backgroundImageStyle` function is a valid image address by matching it against the common image file extensions.

Closes #46 