### PR TITLE
Use utils, update describe pattern

### DIFF
--- a/src/block-class-name/test/index.js
+++ b/src/block-class-name/test/index.js
@@ -1,45 +1,52 @@
 /**
+ * Utility for libraries from the `Lodash`.
+ *
+ * @ignore
+ */
+import { map } from 'lodash';
+
+/**
  * The function to be tested.
  *
  * @ignore
  */
 import blockClassName from '../';
 
-describe( 'Should return the block-specific generated CSS class name when given a string argument containing the class name(s)', () => {
-	it.each( [
-		[ 'wp-block-sixa-spacer', 'wp-block-sixa-spacer' ],
-		[ 'wp-block-sixa-spacer123', 'wp-block-sixa-spacer123' ],
-		[ 'wp-block-sixa__spacer', 'wp-block-sixa__spacer' ],
-		[ 'test-wp-block-sixa-spacer', 'wp-block-sixa-spacer' ], // Containing prefix
-		[ 'wp-block-sixa-spacer test-class-name', 'wp-block-sixa-spacer' ],
-	] )( 'when given %s it returns %s', ( input, expected ) => {
-		expect( blockClassName( input ) ).toBe( expected );
-	} );
-} );
+/**
+ * Set of falsey and empty values for testing.
+ *
+ * @ignore
+ */
+import { falsey, empties } from '../../utils';
 
-describe( 'Should return the first block-specific generated CSS class name when given a string argument containing multiple candidates', () => {
-	it.each( [ [ 'wp-block-sixa-spacer wp-block-sixa-container', 'wp-block-sixa-spacer' ] ] )( 'when given %s it returns %s', ( input, expected ) => {
-		expect( blockClassName( input ) ).toBe( expected );
+describe( 'blockClassName', () => {
+	describe( 'Should return the block-specific generated CSS class name when given a string argument containing the class name(s)', () => {
+		it.each( [
+			[ 'wp-block-sixa-spacer', 'wp-block-sixa-spacer' ],
+			[ 'wp-block-sixa-spacer123', 'wp-block-sixa-spacer123' ],
+			[ 'wp-block-sixa__spacer', 'wp-block-sixa__spacer' ],
+			[ 'test-wp-block-sixa-spacer', 'wp-block-sixa-spacer' ], // Containing prefix
+			[ 'wp-block-sixa-spacer test-class-name', 'wp-block-sixa-spacer' ],
+		] )( 'when given %s it returns %s', ( input, expected ) => {
+			expect( blockClassName( input ) ).toBe( expected );
+		} );
 	} );
-} );
 
-describe( 'Should return `undefined` when the given argument doesn’t contain a valid string of CSS class name(s)', () => {
-	it.each( [
-		[ 'wp--block-sixa-spacer', undefined ],
-		[ [ '' ], undefined ],
-		[ '', undefined ],
-		[ [], undefined ],
-		[ {}, undefined ],
-		[ null, undefined ],
-		[ undefined, undefined ],
-		[ false, undefined ],
-		[ true, undefined ],
-		[ 0, undefined ],
-		[ -0, undefined ],
-		[ 0n, undefined ],
-		[ 1, undefined ],
-		[ NaN, undefined ],
-	] )( 'when given %p it returns %p', ( input, expected ) => {
-		expect( blockClassName( input ) ).toBe( expected );
+	it( 'Should return the first block-specific generated CSS class name when given a string argument containing multiple candidates', () => {
+		expect( blockClassName( 'wp-block-sixa-spacer wp-block-sixa-container' ) ).toBe( 'wp-block-sixa-spacer' );
+	} );
+
+	describe( 'Should accept falsey arguments', () => {
+		const cases = map( falsey, ( value ) => [ value ] );
+		it.each( cases )( 'when given %p', ( input ) => {
+			expect.anything( blockClassName( input ) );
+		} );
+	} );
+
+	describe( 'Should accept empty arguments', () => {
+		const cases = map( empties, ( value ) => [ value ] );
+		it.each( cases )( 'when given %p', ( input ) => {
+			expect.anything( blockClassName( input ) );
+		} );
 	} );
 } );


### PR DESCRIPTION
This PR updated the unit test for the `blockClassName` utility following the new guidelines and and conclusions reached in #51.