### PR TITLE
booleanToString - Use utils, update describe pattern

### DIFF
--- a/src/boolean-to-string/test/index.js
+++ b/src/boolean-to-string/test/index.js
@@ -1,43 +1,56 @@
 /**
+ * Utility for libraries from the `Lodash`.
+ *
+ * @ignore
+ */
+import { map } from 'lodash';
+
+/**
  * The function to be tested.
  *
  * @ignore
  */
 import booleanToString from '../';
 
-describe( 'Should convert a boolean primitive to a "yes" or "no" string', () => {
-	it.each( [
-		[ true, 'yes' ],
-		[ false, 'no' ],
-	] )( 'when given %p it returns %s', ( input, expected ) => {
-		expect( booleanToString( input ) ).toBe( expected );
-	} );
-} );
+/**
+ * Set of falsey and empty values for testing.
+ *
+ * @ignore
+ */
+import { falsey, empties } from '../../utils';
 
-describe( 'Should convert other truthful values to boolean primitive "true"', () => {
-	it.each( [
-		[ 'yes', true ],
-		[ 'true', true ],
-		[ 'TRUE', true ],
-		[ '1', true ],
-	] )( 'when given %s it returns %p', ( input, expected ) => {
-		expect( booleanToString( input ) ).toBe( expected );
+describe( 'booleanToString', () => {
+	describe( 'Should convert a boolean primitive to a "yes" or "no" string', () => {
+		it.each( [
+			[ true, 'yes' ],
+			[ false, 'no' ],
+		] )( 'when given %p it returns %s', ( input, expected ) => {
+			expect( booleanToString( input ) ).toBe( expected );
+		} );
 	} );
-} );
 
-describe( 'Should convert any other input to boolean primitive "false"', () => {
-	it.each( [
-		[ '', false ],
-		[ '0', false ],
-		[ 'no', false ],
-		[ 'false', false ],
-		[ 'FALSE', false ],
-		[ 2, false ],
-		[ {}, false ],
-		[ [], false ],
-		[ null, false ],
-		[ undefined, false ],
-	] )( 'when given %p it returns %p', ( input, expected ) => {
-		expect( booleanToString( input ) ).toBe( expected );
+	describe( 'Should convert other truthful values to boolean primitive "true"', () => {
+		it.each( [
+			[ 'yes', true ],
+			[ 'true', true ],
+			[ 'TRUE', true ],
+			[ '1', true ],
+		] )( 'when given %s it returns %p', ( input, expected ) => {
+			expect( booleanToString( input ) ).toBe( expected );
+		} );
+	} );
+
+	describe( 'Should accept falsey arguments', () => {
+		const cases = map( falsey, ( value ) => [ value ] );
+		it.each( cases )( 'when given %p', ( input ) => {
+			expect.anything( booleanToString( input ) );
+		} );
+	} );
+
+	describe( 'Should accept empty arguments', () => {
+		const cases = map( empties, ( value ) => [ value ] );
+		it.each( cases )( 'when given %p', ( input ) => {
+			expect.anything( booleanToString( input ) );
+		} );
 	} );
 } );


### PR DESCRIPTION
This PR updated the unit test for the `booleanToString` utility following the new guidelines and and conclusions reached in #51.