### PR TITLE
Add jsonify unit test

### DIFF
--- a/src/jsonify/test/index.js
+++ b/src/jsonify/test/index.js
@@ -20,7 +20,7 @@ import jsonify from '../';
 import { falsey, empties } from '../../utils';
 
 describe( 'jsonify', () => {
-	describe( 'Should return valid JSON object for given input string', () => {
+	describe( 'Should return a valid JavaScript object when given a JSON string.', () => {
 		it.each( [
 			[ '[ 1, 2, 3 ]', [ 1, 2, 3 ] ],
 			[ '{ "id": 1, "title": "lorem ipsum" }', { id: 1, title: 'lorem ipsum' } ],


### PR DESCRIPTION
This PR proposes a test suite for the `jsonify` utility.

In terms of valid test cases I'm not sure if it makes sense to extend it further since we cannot expect any other response than a valid JSON output. If the input is invalid for any reason it simply throws a syntax error.

Please let me know your thoughts.