### PR TITLE
Babel ES Module

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-	presets: [ '@babel/preset-env', '@babel/preset-react' ],
+	presets: [ [ '@babel/preset-env', { modules: false } ], '@babel/preset-react' ],
 	minified: true,
 	comments: false,
 	ignore: [ '**/test', '*/utils' ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
 			"version": "1.0.4",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
+				"classnames": "2.3.1",
+				"lodash": "4.17.21",
 				"rename-keys": "^2.0.1",
 				"slugify": "^1.6.0",
 				"striptags": "^3.2.0"
@@ -19,11 +21,9 @@
 				"@babel/preset-env": "^7.15.0",
 				"@babel/preset-react": "7.14.5",
 				"@wordpress/scripts": "^17.1.0",
-				"classnames": "2.3.1",
 				"cross-env": "7.0.3",
 				"husky": "^7.0.1",
-				"lint-staged": "^11.1.2",
-				"lodash": "4.17.21"
+				"lint-staged": "^11.1.2"
 			},
 			"engines": {
 				"node": ">=16",
@@ -7469,8 +7469,7 @@
 		"node_modules/classnames": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-			"dev": true
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
 		},
 		"node_modules/clean-stack": {
 			"version": "2.2.0",
@@ -30986,8 +30985,7 @@
 		"classnames": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
-			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
-			"dev": true
+			"integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA=="
 		},
 		"clean-stack": {
 			"version": "2.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@sixa/wp-block-utils",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@sixa/wp-block-utils",
-			"version": "1.0.3",
+			"version": "1.0.4",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"rename-keys": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,9 @@
 	"dependencies": {
 		"rename-keys": "^2.0.1",
 		"slugify": "^1.6.0",
-		"striptags": "^3.2.0"
+		"striptags": "^3.2.0",
+		"lodash": "4.17.21",
+		"classnames": "2.3.1"
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.14.8",
@@ -56,11 +58,9 @@
 		"@babel/preset-env": "^7.15.0",
 		"@babel/preset-react": "7.14.5",
 		"@wordpress/scripts": "^17.1.0",
-		"classnames": "2.3.1",
 		"cross-env": "7.0.3",
 		"husky": "^7.0.1",
-		"lint-staged": "^11.1.2",
-		"lodash": "4.17.21"
+		"lint-staged": "^11.1.2"
 	},
 	"peerDependencies": {
 		"@wordpress/api-fetch": "5.x",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@sixa/wp-block-utils",
-	"version": "1.0.3",
+	"version": "1.0.4",
 	"description": "A collection of JavaScript utility methods delivering modularity, performance & extras.",
 	"keywords": [
 		"gutenberg",


### PR DESCRIPTION
This PR proposes to use `{ modules: false }` in `@babel/preset-env` to enable webpack tree shaking. In addition, I have bumped the version to `1.0.4` and moved production dependencies from `devDependencies` to `dependencies`.